### PR TITLE
Add h5py to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ docopt
 tensorflow-gpu
 sklearn
 scipy
+h5py


### PR DESCRIPTION
Trying to reproduce results and h5py could not be imported (was not in requirements) so I have added it.